### PR TITLE
Fix skin display

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -401,9 +401,7 @@ project(":forge") {
 
     dependencies {
         val installer = configurations.getByName("installer")
-        val testImplementation = configurations.getByName("testImplementation")
         val implementation = configurations.getByName("implementation")
-        val fmllauncherImplementation = configurations.getByName("fmllauncherImplementation")
 
         installer("org.ow2.asm:asm-debug-all:5.2")
         installer("lzma:lzma:0.0.1")
@@ -1118,6 +1116,9 @@ project(":forge") {
         include("cpw/mods/fml/")
             
         tasks {
+            register("fmlllauncher") {
+                files = files("$rootDir/src/fmlllauncher/java")
+            }
             register("main") {
                 files = files("$rootDir/src/main/java")
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -403,6 +403,7 @@ project(":forge") {
         val installer = configurations.getByName("installer")
         val testImplementation = configurations.getByName("testImplementation")
         val implementation = configurations.getByName("implementation")
+        val fmllauncherImplementation = configurations.getByName("fmllauncherImplementation")
 
         installer("org.ow2.asm:asm-debug-all:5.2")
         installer("lzma:lzma:0.0.1")
@@ -410,6 +411,12 @@ project(":forge") {
         installer("com.google.guava:guava:14.0")
         installer("com.google.code.gson:gson:2.3")
         installer("net.sourceforge.argo:argo:2.25")
+        installer("com.mojang:authlib:2.1.28")
+        installer("org.apache.logging.log4j:log4j-core:2.5")
+        installer("org.apache.logging.log4j:log4j-api:2.5")
+        installer("org.apache.commons:commons-lang3:3.12.0")
+        installer("commons-io:commons-io:2.10.0")
+        installer("commons-codec:commons-codec:1.15")
 
         //testImplementation("org.junit.jupiter:junit-jupiter-api:5.0.0")
         //testImplementation("org.junit.vintage:junit-vintage-engine:5.+")
@@ -665,10 +672,8 @@ project(":forge") {
         }
         
         register("launcherJson") {
-            val launcherJar = getByName<Jar>("launcherJar")
             dependsOn(launcherJar)
             
-            val launcherJarFile = launcherJar.archiveFile.get().asFile
             val vanilla = project(":mcp").file("build/mcp/downloadJson/version.json")
             val version = project.version as String
             val idx = version.indexOf('-')
@@ -704,6 +709,7 @@ project(":forge") {
                     put("minecraftArguments", listOf(
                             "\${auth_player_name}",
                             "\${auth_session}",
+                            "--uuid", "\${auth_uuid}",
                             "--gameDir", "\${game_directory}",
                             "--assetsDir", "\${game_assets}"
                     ).joinToString(separator = " "))
@@ -913,7 +919,6 @@ project(":forge") {
             val genClientBinPatches = getByName("genClientBinPatches")
             val genServerBinPatches = getByName("genServerBinPatches")
             val universalJar = getByName("universalJar")
-            val launcherJar = getByName("launcherJar")
             
             dependsOn("downloadInstaller", installerJson, launcherJson, genClientBinPatches, genServerBinPatches, universalJar)
             archiveClassifier.set("installer")
@@ -984,6 +989,8 @@ project(":forge") {
         }
         
         named<ProcessResources>("processFmllauncherResources") {
+            inputs.property("version", project.version)
+            
             from(project.extensions.getByType(SourceSetContainer::class).getByName("fmllauncher").resources) {
                 filesMatching("*.properties") {
                     filter(ReplaceTokens::class, tokenMap)

--- a/patches/minecraft/net/minecraft/client/entity/EntityOtherPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityOtherPlayerMP.java.patch
@@ -1,0 +1,28 @@
+--- a/net/minecraft/client/entity/EntityOtherPlayerMP.java
++++ b/net/minecraft/client/entity/EntityOtherPlayerMP.java
+@@ -1,5 +1,7 @@
+ package net.minecraft.client.entity;
+ 
++import com.mojang.authlib.minecraft.MinecraftProfileTexture;
++import cpw.mods.fml.relauncher.FMLAuth;
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
+ import net.minecraft.client.Minecraft;
+@@ -32,7 +34,7 @@
+ 
+         if (p_i3117_2_ != null && p_i3117_2_.length() > 0)
+         {
+-            this.field_70120_cr = "http://skins.minecraft.net/MinecraftSkins/" + StringUtils.func_76338_a(p_i3117_2_) + ".png";
++            this.field_70120_cr = FMLAuth.instance.getTextureURL(MinecraftProfileTexture.Type.SKIN);
+         }
+ 
+         this.field_70145_X = true;
+@@ -62,7 +64,7 @@
+ 
+     public void func_70059_ac()
+     {
+-        this.field_71084_cw = "http://skins.minecraft.net/MinecraftCloaks/" + StringUtils.func_76338_a(this.field_71092_bJ) + ".png";
++        this.field_71084_cw = FMLAuth.instance.getTextureURL(MinecraftProfileTexture.Type.CAPE);
+         this.field_70119_cs = this.field_71084_cw;
+     }
+ 

--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -1,0 +1,28 @@
+--- a/net/minecraft/client/entity/EntityPlayerSP.java
++++ b/net/minecraft/client/entity/EntityPlayerSP.java
+@@ -1,5 +1,7 @@
+ package net.minecraft.client.entity;
+ 
++import com.mojang.authlib.minecraft.MinecraftProfileTexture;
++import cpw.mods.fml.relauncher.FMLAuth;
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
+ import net.minecraft.client.Minecraft;
+@@ -69,7 +71,7 @@
+ 
+         if (p_i3116_3_ != null && p_i3116_3_.field_74286_b != null && p_i3116_3_.field_74286_b.length() > 0)
+         {
+-            this.field_70120_cr = "http://skins.minecraft.net/MinecraftSkins/" + StringUtils.func_76338_a(p_i3116_3_.field_74286_b) + ".png";
++            this.field_70120_cr = FMLAuth.instance.getTextureURL(MinecraftProfileTexture.Type.SKIN);
+         }
+ 
+         this.field_71092_bJ = p_i3116_3_.field_74286_b;
+@@ -296,7 +298,7 @@
+ 
+     public void func_70059_ac()
+     {
+-        this.field_71084_cw = "http://skins.minecraft.net/MinecraftCloaks/" + StringUtils.func_76338_a(this.field_71092_bJ) + ".png";
++        this.field_71084_cw = FMLAuth.instance.getTextureURL(MinecraftProfileTexture.Type.CAPE);
+         this.field_70119_cs = this.field_71084_cw;
+     }
+ 

--- a/src/fmllauncher/java/cpw/mods/fml/relauncher/FMLAuth.java
+++ b/src/fmllauncher/java/cpw/mods/fml/relauncher/FMLAuth.java
@@ -1,0 +1,28 @@
+package cpw.mods.fml.relauncher;
+
+import com.mojang.authlib.minecraft.MinecraftProfileTexture;
+import com.mojang.authlib.minecraft.MinecraftSessionService;
+import com.mojang.authlib.GameProfile;
+
+import java.util.Map;
+
+public class FMLAuth {
+    public static FMLAuth instance;
+    
+    private final GameProfile profile;
+    private final MinecraftSessionService sessionService;
+    
+    public FMLAuth(GameProfile profile, MinecraftSessionService sessionService) {
+        this.profile = profile;
+        this.sessionService = sessionService;
+        
+        sessionService.fillProfileProperties(profile, false);
+    }
+    
+    public String getTextureURL(MinecraftProfileTexture.Type type) {
+        Map<MinecraftProfileTexture.Type, MinecraftProfileTexture> textures = sessionService.getTextures(profile, false);
+        if (textures.containsKey(type)) return textures.get(type).getUrl();
+        
+        return "unknown";
+    }
+}

--- a/src/fmllauncher/java/cpw/mods/fml/relauncher/FMLAuth.java
+++ b/src/fmllauncher/java/cpw/mods/fml/relauncher/FMLAuth.java
@@ -1,3 +1,17 @@
+/*
+ * The FML Forge Mod Loader suite.
+ * Copyright (C) 2012 cpw
+ *
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
 package cpw.mods.fml.relauncher;
 
 import com.mojang.authlib.minecraft.MinecraftProfileTexture;

--- a/src/fmllauncher/java/cpw/mods/fml/relauncher/FMLRelauncher.java
+++ b/src/fmllauncher/java/cpw/mods/fml/relauncher/FMLRelauncher.java
@@ -23,11 +23,8 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class FMLRelauncher {

--- a/src/fmllauncher/java/cpw/mods/fml/relauncher/LibraryFinder.java
+++ b/src/fmllauncher/java/cpw/mods/fml/relauncher/LibraryFinder.java
@@ -1,3 +1,17 @@
+/*
+ * The FML Forge Mod Loader suite.
+ * Copyright (C) 2012 cpw
+ *
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
 package cpw.mods.fml.relauncher;
 
 import net.minecraftforge.common.ForgeVersion;

--- a/src/fmllauncher/java/cpw/mods/fml/relauncher/RelaunchClassLoader.java
+++ b/src/fmllauncher/java/cpw/mods/fml/relauncher/RelaunchClassLoader.java
@@ -62,6 +62,7 @@ public class RelaunchClassLoader extends URLClassLoader {
         addClassLoaderExclusion("sun.");
         addClassLoaderExclusion("org.lwjgl.");
         addClassLoaderExclusion("cpw.mods.fml.relauncher.");
+        addClassLoaderExclusion("com.mojang.authlib.");
         //addClassLoaderExclusion("net.minecraftforge.classloading.");
 
         // standard transformer exclusions

--- a/src/fmllauncher/java/cpw/mods/fml/relauncher/wrapper/ClientLaunchWrapper.java
+++ b/src/fmllauncher/java/cpw/mods/fml/relauncher/wrapper/ClientLaunchWrapper.java
@@ -14,11 +14,80 @@
 
 package cpw.mods.fml.relauncher.wrapper;
 
+import com.mojang.authlib.Agent;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.UserAuthentication;
+import com.mojang.authlib.exceptions.AuthenticationException;
+import com.mojang.authlib.minecraft.MinecraftSessionService;
+import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
+import com.mojang.util.UUIDTypeAdapter;
+import cpw.mods.fml.relauncher.FMLAuth;
 import cpw.mods.fml.relauncher.FMLRelauncher;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import joptsimple.OptionSpecBuilder;
+
+import java.net.Proxy;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
 
 public class ClientLaunchWrapper {
     
     public static void main(String[] args) {
-        FMLRelauncher.handleClientRelaunch(args);
+        FMLRelauncher.handleClientRelaunch(prepareArgs(args));
+    }
+
+    /**
+     * Basic implementation of Mojang's 'Yggdrasil' login system, purely intended as a dev time bare bones login.
+     * Login errors are not handled.
+     * Do not use this unless you know what you are doing and must use it to debug things REQUIRING authentication.
+     * Forge is not responsible for any auth information passed in, saved to logs, run configs, etc...
+     * BE CAREFUL WITH YOUR LOGIN INFO
+     *
+     * <p>Javadoc Credit: MinecraftForge</p>
+     */
+    public static String[] prepareArgs(String[] args) {
+        OptionParser parser = new OptionParser();
+        parser.allowsUnrecognizedOptions();
+        Stream.of("version", "assetIndex", "gameDir", "assetsDir", "accessToken", "userProperties")
+                .map(parser::accepts)
+                .forEach(OptionSpecBuilder::withRequiredArg);
+        OptionSpec<String> uuid = parser.accepts("uuid").withRequiredArg();
+        OptionSpec<String> username = parser.accepts("username").withRequiredArg();
+        OptionSpec<String> password = parser.accepts("password").withRequiredArg();
+        OptionSpec<String> nonOptions = parser.nonOptions();
+        OptionSet optionSet = parser.parse(args);
+        List<String> values = nonOptions.values(optionSet);
+
+        YggdrasilAuthenticationService authService = new YggdrasilAuthenticationService(Proxy.NO_PROXY, "1");
+        MinecraftSessionService sessionService = authService.createMinecraftSessionService();
+        if (optionSet.has(username) && optionSet.has(password)) {
+            String usernameValue = username.value(optionSet);
+            UserAuthentication auth = authService.createUserAuthentication(Agent.MINECRAFT);
+            auth.setUsername(usernameValue);
+            auth.setPassword(password.value(optionSet));
+
+            try {
+                auth.logIn();
+            } catch (AuthenticationException e) {
+                throw new RuntimeException("Login failed!", e);
+            }
+
+            UUID uuidValue = auth.getSelectedProfile().getId();
+            GameProfile profile = new GameProfile(uuidValue, usernameValue);
+            FMLAuth.instance = new FMLAuth(profile, sessionService);
+            String uuidString = uuidValue.toString().replace("-", "");
+            return Stream.concat(Stream.of(usernameValue, "token:" + auth.getAuthenticatedToken() + ":" + uuidString), values.stream())
+                    .toArray(String[]::new);
+        }
+
+        if (!optionSet.has(uuid))
+            throw new RuntimeException("UUID option is required when username/password are not specified");
+        GameProfile profile = new GameProfile(UUIDTypeAdapter.fromString(uuid.value(optionSet)), values.get(0));
+        FMLAuth.instance = new FMLAuth(profile, sessionService);
+
+        return values.toArray(new String[0]);
     }
 }


### PR DESCRIPTION
Fixes displaying skins & capes.  
On launch, FML will get and store the player's `GameProfile`. Then, when the player entity is constructed, it will use that profile to find available textures for the player.  

Dev launch args provided by legacydev will also be filtered out and properly passed to minecraft.